### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ This is an iOS control for showing multiple view controller in one view controll
 ### Landscape
 ![Landscape](http://cooperrs.github.io/RMMultipleViewsController/Images/Screen2.png)
 
-##Installation
-###Manual
+## Installation
+### Manual
 1. Check out the project
 2. Add all files in `RMMultipleViewsController` folder to Xcode
 
-###CocoaPods
+### CocoaPods
 ```ruby
 platform :ios, '7.0'
 pod "RMMultipleViewsController", "~> 1.0.1"
 ```
 
-##Usage
-###Basic
+## Usage
+### Basic
 1. Create a subclass of `RMMultipleViewsController` in your project.
 	
 	```objc


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
